### PR TITLE
Support for cross-module proto definition parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 Debug
 .cproject
 .project
+*.i*
 erl_protobuf_test/.eunit/
 erl_protobuf_test/deps/
 erl_protobuf_test/ebin/

--- a/src/ErlangGenerator.h
+++ b/src/ErlangGenerator.h
@@ -139,55 +139,45 @@ private:
 	  return out.str();
 	}
 
+	inline const string normalize_string(const string& orig) const
+    {
+        std::stringstream out;
+
+        for(string::const_iterator sI=orig.begin();sI != orig.end(); ++sI)
+        {
+            if(*sI == '.')
+              out << "_";
+            else
+              out << *sI;
+        }
+        return out.str();
+    }
+
 	inline const string file_basename(const string& filename)  const {
 	  return filename.substr(0,filename.find(".proto")).substr(filename.find_last_of('/')+1);
 	}
 
 	inline const string module_name(const FileDescriptor* file)  const {
-	  return to_atom(file_basename(file->name())+"_pb");
+	  return to_atom(normalize_string(file->package().empty() ? "" : file->package() + "_") + file_basename(file->name()) + "_pb");
 	}
 
 	inline const std::string normalized_scope(const string& full_name, const string& package="") const
 	{
-	  std::stringstream out;
 	  string name;
 	  if(!package.empty())
 	    name=full_name.substr(package.size()+1);
 	  else
 	    name=full_name;
-	  for(string::const_iterator sI=name.begin();sI != name.end(); ++sI)
-	  {
-	    if(*sI == '.')
-	      out << "__";
-	    else
-	      out << *sI;
-	  }
-	  return out.str();
+	  return normalize_string(name);
 	}
 	
-	inline const std::string normalized_module_name(const FileDescriptor* file) const
-	{
-    std::stringstream out;
-    string name = module_name(file);
-    
-    for(string::const_iterator sI=name.begin();sI != name.end(); ++sI)
-	  {
-	    if(*sI == '.')
-	      out << "__";
-	    else
-	      out << *sI;
-	  }
-	  return out.str();
-	}
-
 	inline const std::string normalized_scope(const Descriptor* d) const
 	{
 	  if(is_strict_naming)
 	    return normalized_scope(d->full_name(),d->file()->package());
 	  else
-      return normalized_scope(d->full_name(),d->file()->package());
+        return normalized_scope(d->full_name(),d->file()->package());
 	}
-
 
 	inline const string record_name(const Descriptor* message, const string& prefix="", const string& postfix="")  const {
 	  return to_atom(prefix

--- a/src/ErlangGenerator.h
+++ b/src/ErlangGenerator.h
@@ -164,6 +164,21 @@ private:
 	  }
 	  return out.str();
 	}
+	
+	inline const std::string normalized_module_name(const FileDescriptor* file) const
+	{
+    std::stringstream out;
+    string name = module_name(file);
+    
+    for(string::const_iterator sI=name.begin();sI != name.end(); ++sI)
+	  {
+	    if(*sI == '.')
+	      out << "__";
+	    else
+	      out << *sI;
+	  }
+	  return out.str();
+	}
 
 	inline const std::string normalized_scope(const Descriptor* d) const
 	{
@@ -219,6 +234,11 @@ private:
   inline const std::string decode_impl_name(const Descriptor* d) const
   {
     return to_atom(string("decode_") + normalized_scope(d)+"_impl");
+  }
+  
+  inline const std::string decode_msg_name(const Descriptor* d) const
+  {
+    return to_atom(module_name(d->file()) + string(":") + decode_name(d));
   }
 
 	inline const std::string encode_name(const Descriptor* d) const

--- a/src/ErlangGenerator.h
+++ b/src/ErlangGenerator.h
@@ -202,7 +202,11 @@ private:
 	}
 
 	inline const string field_name(const FieldDescriptor* field)  const {
-	  return to_atom(field->name());
+	  //TODO: Add checks for erlang keywords
+	  if ("end" == field->name() || "begin" == field->name())
+	    return to_atom(field->name() + string("_"));
+	  else
+	    return to_atom(field->name());
 	}
 
 	inline const string field_tag(const FieldDescriptor* field)  const {
@@ -245,6 +249,11 @@ private:
 	{
 	  return to_atom(string("encode_") + normalized_scope(d));
 	}
+
+	inline const std::string encode_msg(const Descriptor* d) const
+    {
+      return to_atom(module_name(d->file()) + string(":") + encode_name(d));
+    }
 
 	inline const std::string to_enum_name(const EnumDescriptor* d) const
 	{

--- a/src/ErlangSourceGenerator.cpp
+++ b/src/ErlangSourceGenerator.cpp
@@ -108,7 +108,7 @@ void ErlangGenerator::field_to_decode_function(Printer &out, const FieldDescript
       break;
     case FieldDescriptor::TYPE_ENUM:
       // As with integer types, but the additional step of to_enum()
-      vars["to_enum"]=to_enum_name(field->enum_type());
+      vars["to_enum"]=module_name(field->file()) + string(":") + to_enum_name(field->enum_type());
       if(field->is_repeated())
         out.Print(vars,"($id$,{varint,Enum},#$rec${$field$=F}=Rec) when is_list(F) -> Rec#$rec${$field$=Rec#$rec$.$field$ ++ [$to_enum$(Enum)]}\n");
       else
@@ -210,7 +210,7 @@ void ErlangGenerator::encode_decode_for_message(Printer& out, const Descriptor* 
 
     switch(field->type()) {
     case FieldDescriptor::TYPE_ENUM:
-      vars["from_enum"]=from_enum_name(field->enum_type());
+      vars["from_enum"]=module_name(field->file()) + string(":") + from_enum_name(field->enum_type());
       if(field->is_repeated())
       {
         out.Print(vars,"    [protocol_buffers:encode($id$,int32,$from_enum$(X)) || X <- R#$rec$.$field$]");

--- a/src/ErlangSourceGenerator.cpp
+++ b/src/ErlangSourceGenerator.cpp
@@ -97,7 +97,10 @@ void ErlangGenerator::field_to_decode_function(Printer &out, const FieldDescript
       break;
     case FieldDescriptor::TYPE_MESSAGE:
       // No such thing as a packed series of messages, so just append/replace multiple encounters.
-      vars["decode"]=decode_impl_name(field->message_type());
+      if (module_name(field->containing_type()->file()) == module_name(field->message_type()->file()))
+        vars["decode"]=decode_impl_name(field->message_type());
+      else
+        vars["decode"]=decode_msg_name(field->message_type());
       if(field->is_repeated())
         out.Print(vars,"($id$,{length_encoded,Bin},#$rec${$field$=F}=Rec) when is_list(F) -> Rec#$rec${$field$ = Rec#$rec$.$field$ ++ [$decode$(Bin)]}\n");
       else


### PR DESCRIPTION
Added support for adding module names to the generated code to properly handle message records that belong to another .proto file (module) as well as handle cases where duplicate module names exist (due to the duplicate names of .proto files) but living in the different folders.
