### PR TITLE
Move library linking to end of g++ invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 SRC_DIR := src
 BIN_DIR := bin
 SOURCES := ${wildcard ${SRC_DIR}/*.cpp} ${wildcard ${SRC_DIR}/*.cc}
@@ -10,9 +9,9 @@ default: ${EXE}
 
 ${EXE}: ${SOURCES} ${HEADERS}
 	mkdir -p ${BIN_DIR}
-	g++ -Wall -g -lprotobuf -lprotoc -lpthread -o $@ ${SOURCES}
-	
-	
+	g++ -Wall -g -o $@ ${SOURCES} -lprotobuf -lprotoc -lpthread
+
+
 test: ${EXE}
 	-rm -rf output
 	mkdir output


### PR DESCRIPTION
See http://gcc.gnu.org/onlinedocs/gcc/Link-Options.html

The protoc and protobuf libraries are linked in the middle of the g++ invocation which will cause them to not compile in certain systems.
