### PR TITLE
Fixed broken Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ default: ${EXE}
 
 ${EXE}: ${SOURCES} ${HEADERS}
 	mkdir -p ${BIN_DIR}
-	g++ -Wall -g -lprotobuf -lprotoc -lpthread -o $@ ${SOURCES}
+	$(CXX) -Wall -g -o $@ ${SOURCES} -lprotobuf -lprotoc -lpthread
 	
 	
 test: ${EXE}


### PR DESCRIPTION
The order of modules and libraries does not work on ubuntu 12.04.
Now links on ubuntu 12.04, see https://wiki.ubuntu.com/NattyNarwhal/ToolchainTransition
