### PR TITLE
Fixed "repeated" output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ default: ${EXE}
 
 ${EXE}: ${SOURCES} ${HEADERS}
 	mkdir -p ${BIN_DIR}
-	g++ -Wall -g -lprotobuf -lprotoc -lpthread -o $@ ${SOURCES}
+	g++ -Wall -g -o $@ ${SOURCES} -lprotobuf -lprotoc -lpthread
 	
 	
 test: ${EXE}

--- a/src/ErlangSourceGenerator.cpp
+++ b/src/ErlangSourceGenerator.cpp
@@ -231,7 +231,10 @@ void ErlangGenerator::encode_decode_for_message(Printer& out, const Descriptor* 
       break;
 
     default:
-      out.Print(vars,"    protocol_buffers:encode($id$,$type$,R#$rec$.$field$)");
+      if(field->is_repeated())
+        out.Print(vars,"    [ protocol_buffers:encode($id$,$type$,X) || X <- R#$rec$.$field$]");
+      else
+        out.Print(vars,"    protocol_buffers:encode($id$,$type$,R#$rec$.$field$)");
     }
     if(i<d->field_count()-1)
       out.PrintRaw(",\n");


### PR DESCRIPTION
- our use case is _specifically_ for repeated int32, and this modification was not tested for much else
- make ; make install presents no problem, though ("All 16 tests passed.")
